### PR TITLE
Using EloquentTree in another database

### DIFF
--- a/src/Gzero/EloquentTree/Model/Observer.php
+++ b/src/Gzero/EloquentTree/Model/Observer.php
@@ -33,7 +33,7 @@ class Observer {
     {
         if ($model->{$model->getTreeColumn('path')} === '') { // If we just save() new node
             $model->{$model->getTreeColumn('path')} = $model->getKey() . '/';
-            DB::table($model->getTable())
+            DB::connection($model->getConnectionName())->table($model->getTable())
                 ->where($model->getKeyName(), '=', $model->getKey())
                 ->update(
                     array(


### PR DESCRIPTION
I am working in a project with multiple databases. And we use the Eloquent Tree at one database who at not the application database default. This line code causes an error because the application it was looking the table in wrong database.

Please forgive me the english. I'm still practing.